### PR TITLE
Prevent warnings if the app isn't setting a Content-Type

### DIFF
--- a/lib/Plack/Middleware/CSRFBlock.pm
+++ b/lib/Plack/Middleware/CSRFBlock.pm
@@ -122,6 +122,9 @@ sub call {
     return $self->response_cb($self->app->($env), sub {
         my $res = shift;
         my $ct = Plack::Util::header_get($res->[1], 'Content-Type');
+        # prevents warnings if the app isn't setting a content-type
+        return $res
+            if not defined $ct;
         if($ct !~ m{^text/html}i and $ct !~ m{^application/xhtml[+]xml}i){
             return $res;
         }


### PR DESCRIPTION
If (for whatever reason) your app isn't setting a Content-Type header there's no point in continuing with the CSRF

Currently CSRFBlock warns something like:

  Use of uninitialized value $ct in pattern match (m//) at /PATH/TO/lib/site_perl/5.12.4/Plack/Middleware/CSRFBlock.pm line 125.

Yes, the app needs fixing, but there's no reason why this middleware shouldn't DTRT and avoid spitting out warnings.
