### PR TITLE
Code tweak + documentation fix

### DIFF
--- a/lib/Plack/Middleware/CSRFBlock.pm
+++ b/lib/Plack/Middleware/CSRFBlock.pm
@@ -235,7 +235,7 @@ this becomes:
   <html>
     <head><title>input form</title></head>
     <body>
-      <form action="/api" method="post"><input type="hidden" name="SEC" value="0f15ba869f1c0d77" />
+      <form action="/receive" method="post"><input type="hidden" name="SEC" value="0f15ba869f1c0d77" />
         <input type="text" name="email" /><input type="submit" />
       </form>
   </html>

--- a/lib/Plack/Middleware/CSRFBlock.pm
+++ b/lib/Plack/Middleware/CSRFBlock.pm
@@ -127,7 +127,12 @@ sub call {
         }
 
         my @out;
-        my $http_host = exists $env->{HTTP_HOST} ? $env->{HTTP_HOST} : $env->{SERVER_NAME};
+        my $http_host
+            = exists $env->{HTTP_X_FORWARDED_HOST}
+            ? $env->{HTTP_X_FORWARDED_HOST}
+            : exists $env->{HTTP_HOST} ? $env->{HTTP_HOST}
+            :                            $env->{SERVER_NAME};
+ 
         my $token = $session->{$self->session_key} ||= $self->_token_generator->();
         my $parameter_name = $self->parameter_name;
 


### PR DESCRIPTION
Hi Rintaro,

First off, thanks very much for your work.  :)  I was testing CSRFBlock today on an app which is being served via proxy. I had to make a small code change in order for $http_host to match in the regex.  The issue was that HTTP_HOST had ":443" appended to it.  Rather than strip out the port in $http_host, I opted to default it to HTTP_X_FORWARDED_HOST if it exists and then to fall back to HTTP_HOST.  

This fixed the issue for me.  Maybe someone else will find this helpful as well?

Best,

Olaf
